### PR TITLE
feat(manager): add write key and validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 )
 
 require (
+	github.com/brianvoe/gofakeit/v6 v6.26.3
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,46 @@ module github.com/ormushq/ormus
 go 1.21.0
 
 require (
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/scylladb/go-reflectx v1.0.1 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/fatih/structs v1.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/gocql/gocql v1.6.0
+	github.com/golang-migrate/migrate/v4 v4.16.2
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/knadh/koanf v1.5.0
+	github.com/labstack/echo/v4 v4.11.3
+	github.com/labstack/gommon v0.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.3.0
+	github.com/scylladb/gocqlx/v2 v2.8.0
+	github.com/stretchr/testify v1.8.4
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.2 // indirect
+	golang.org/x/crypto v0.16.0 // indirect
+	golang.org/x/net v0.19.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20231127180814-3a041ad873d4 // indirect
+	google.golang.org/grpc v1.59.0
+	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/knadh/koanf v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/redis/go-redis/v9 v9.3.0
 	github.com/scylladb/gocqlx/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYE
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/brianvoe/gofakeit/v6 v6.26.3 h1:3ljYrjPwsUNAUFdUIr2jVg5EhKdcke/ZLop7uVg1Er8=
+github.com/brianvoe/gofakeit/v6 v6.26.3/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=

--- a/go.sum
+++ b/go.sum
@@ -252,12 +252,15 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/npillmayer/nestext v0.1.3/go.mod h1:h2lrijH8jpicr25dFY+oAJLyzlya6jhnuG+zWp9L0Uk=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
+github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.7.0 h1:7utD74fnzVc/cpcyy8sjrlFr5vYpypUixARcHIMIGuI=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/write_key/writekey.go
+++ b/pkg/write_key/writekey.go
@@ -2,34 +2,15 @@ package writekey
 
 import (
 	"crypto/rand"
-	"fmt"
-	"sync"
 	"time"
 
 	"github.com/oklog/ulid/v2"
-	"github.com/ormushq/ormus/logger"
 )
 
-var entropyPool = sync.Pool{
-	New: func() any {
-		entropy := ulid.Monotonic(rand.Reader, 0)
-
-		return entropy
-	},
-}
-
 func newULID() (string, error) {
-	e := entropyPool.Get()
-
-	entropy, ok := e.(*ulid.MonotonicEntropy)
-	if !ok {
-		logger.L().Info("Unable to Convert Interface to ULID")
-
-		return "", fmt.Errorf("unable to Convert Interface to ULID")
-	}
+	entropy := ulid.Monotonic(rand.Reader, 0)
 
 	s := ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String()
-	entropyPool.Put(e)
 
 	return s, nil
 }

--- a/pkg/write_key/writekey.go
+++ b/pkg/write_key/writekey.go
@@ -1,8 +1,8 @@
 package writekey
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -12,8 +12,7 @@ import (
 
 var entropyPool = sync.Pool{
 	New: func() any {
-		seed := rand.New(rand.NewSource(time.Now().UnixNano()))
-		entropy := ulid.Monotonic(seed, 0)
+		entropy := ulid.Monotonic(rand.Reader, 0)
 
 		return entropy
 	},
@@ -42,7 +41,6 @@ func GenerateNewWriteKey() (string, error) {
 func ValidateWriteKey(writeKey string) error {
 	_, err := ulid.Parse(writeKey)
 	if err != nil {
-
 		return err
 	}
 

--- a/pkg/write_key/writekey.go
+++ b/pkg/write_key/writekey.go
@@ -1,0 +1,50 @@
+package writekey
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/ormushq/ormus/logger"
+)
+
+var entropyPool = sync.Pool{
+	New: func() any {
+		seed := rand.New(rand.NewSource(time.Now().UnixNano()))
+		entropy := ulid.Monotonic(seed, 0)
+
+		return entropy
+	},
+}
+
+func newULID() (string, error) {
+	e := entropyPool.Get()
+
+	entropy, ok := e.(*ulid.MonotonicEntropy)
+	if !ok {
+		logger.L().Info("Unable to Convert Interface to ULID")
+
+		return "", fmt.Errorf("unable to Convert Interface to ULID")
+	}
+
+	s := ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String()
+	entropyPool.Put(e)
+
+	return s, nil
+}
+
+func GenerateNewWriteKey() (string, error) {
+	return newULID()
+}
+
+func ValidateWriteKey(writeKey string) error {
+	_, err := ulid.Parse(writeKey)
+	if err != nil {
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/write_key/writekey_test.go
+++ b/pkg/write_key/writekey_test.go
@@ -49,7 +49,6 @@ func TestWriteKeyValidation(t *testing.T) {
 
 	var wg sync.WaitGroup
 	ids := make([]string, 0)
-	fakeIDs := make([]string, 0)
 
 	for i := 0; i < 1000000; i++ {
 
@@ -78,6 +77,13 @@ func TestWriteKeyValidation(t *testing.T) {
 			}
 		}
 	}
+
+}
+
+func TestWriteKeyInValidation(t *testing.T) {
+
+	var wg sync.WaitGroup
+	fakeIDs := make([]string, 0)
 
 	for i := 0; i < 1000000; i++ {
 

--- a/pkg/write_key/writekey_test.go
+++ b/pkg/write_key/writekey_test.go
@@ -1,0 +1,78 @@
+package writekey_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	writekey "github.com/ormushq/ormus/pkg/write_key"
+)
+
+func TestWriteKeyUniqueness(t *testing.T) {
+
+	var wg sync.WaitGroup
+	ids := make([]string, 0)
+
+	for i := 0; i < 1000000; i++ {
+
+		wg.Add(1)
+		go func() {
+
+			id, err := writekey.GenerateNewWriteKey()
+			if err != nil {
+				t.Errorf("error while generating writekey")
+				return
+			}
+
+			ids = append(ids, id)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	m := make(map[string]bool)
+	for _, id := range ids {
+		fmt.Println(id)
+		if m[id] {
+			t.Errorf("there is same write key")
+			return
+		}
+	}
+
+}
+
+func TestWriteKeyValidation(t *testing.T) {
+
+	var wg sync.WaitGroup
+	ids := make([]string, 0)
+
+	for i := 0; i < 1000000; i++ {
+
+		wg.Add(1)
+		go func() {
+
+			id, err := writekey.GenerateNewWriteKey()
+			if err != nil {
+				t.Errorf("error while generating writekey")
+				return
+			}
+
+			ids = append(ids, id)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	for _, id := range ids {
+		if id != "" {
+			_, err := ulid.Parse(id)
+			if err != nil {
+				t.Errorf("error while validation writekey %s, id: >%s<", err.Error(), id)
+				return
+			}
+		}
+	}
+}

--- a/source/delivery/httpserver/server.go
+++ b/source/delivery/httpserver/server.go
@@ -15,7 +15,7 @@ type Server struct {
 	userhandler userhandler.Handler
 }
 
-// New Set up a new server object.
+// Setup a new server object
 func New(c source.Config) Server {
 	return Server{
 		config: source.Config{


### PR DESCRIPTION
## some description

- I used sync.pool because allocating and freeing objects with high frequency can be relatively expensive. a common technique for improving performance is re-using memory.
sync.Pool is a thread-safe cache for re-using allocations. 
