### PR TITLE
fix(ormus): Add abstract logger

### DIFF
--- a/cmd/pkg/example/logger/main.go
+++ b/cmd/pkg/example/logger/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"github.com/ormushq/ormus/logger/newlogger"
+	"github.com/ormushq/ormus/logger/newlogger/loggerparam"
+	"time"
+)
+
+func main() {
+	newlogger.NewLogger(newlogger.Config{
+		Driver:     "slog",
+		Level:      "debug",
+		Filepath:   "logs/logs.json",
+		LocalTime:  false,
+		MaxBackups: 10,
+		MaxSize:    10,
+		MaxAge:     30,
+	})
+
+	extraKeyValue := "extra key not defined"
+
+	newlogger.NewLog("Test Debug").
+		WithCategory(loggerparam.CategoryNotDefined).
+		WithSubCategory(loggerparam.SubCategoryNotDefined).
+		With(loggerparam.ExtraKeyNotDefined, extraKeyValue).
+		WithTrace().
+		Debug()
+	newlogger.L().Debugf("Test Debugf %v", time.Now())
+
+	newlogger.NewLog("Test Info").
+		WithCategory(loggerparam.CategoryNotDefined).
+		WithSubCategory(loggerparam.SubCategoryNotDefined).
+		With(loggerparam.ExtraKeyNotDefined, extraKeyValue).
+		WithTrace().
+		Info()
+	newlogger.L().Infof("Test Infof %v", time.Now())
+
+	newlogger.NewLog("Test Warn").
+		WithCategory(loggerparam.CategoryNotDefined).
+		WithSubCategory(loggerparam.SubCategoryNotDefined).
+		With(loggerparam.ExtraKeyNotDefined, extraKeyValue).
+		WithTrace().
+		Warn()
+	newlogger.L().Warnf("Test Warnf %v", time.Now())
+
+	newlogger.NewLog("Test Error").
+		WithCategory(loggerparam.CategoryNotDefined).
+		WithSubCategory(loggerparam.SubCategoryNotDefined).
+		With(loggerparam.ExtraKeyNotDefined, extraKeyValue).
+		WithTrace().
+		Error()
+	newlogger.L().Errorf("Test Errorf %v", time.Now())
+
+	newlogger.NewLog("Test Fatal").
+		WithCategory(loggerparam.CategoryNotDefined).
+		WithSubCategory(loggerparam.SubCategoryNotDefined).
+		With(loggerparam.ExtraKeyNotDefined, extraKeyValue).
+		WithTrace().
+		Fatal()
+	newlogger.L().Fatalf("Test Fatalf %v", time.Now())
+}

--- a/cmd/pkg/example/logger/main.go
+++ b/cmd/pkg/example/logger/main.go
@@ -7,14 +7,18 @@ import (
 )
 
 func main() {
+	MaxBackups := 10
+	MaxSize := 10
+	MaxAge := 30
+
 	newlogger.NewLogger(newlogger.Config{
 		Driver:     "slog",
 		Level:      "debug",
 		Filepath:   "logs/logs.json",
 		LocalTime:  false,
-		MaxBackups: 10,
-		MaxSize:    10,
-		MaxAge:     30,
+		MaxBackups: MaxBackups,
+		MaxSize:    MaxSize,
+		MaxAge:     MaxAge,
 	})
 
 	extraKeyValue := "extra key not defined"

--- a/logger/newlogger/adapter/slog/helper.go
+++ b/logger/newlogger/adapter/slog/helper.go
@@ -1,0 +1,16 @@
+package slog
+
+import (
+	"github.com/ormushq/ormus/logger/newlogger/loggerparam"
+	"log/slog"
+)
+
+func logParamsToSlogParams(keys map[loggerparam.ExtraKey]interface{}) []any {
+	params := make([]any, 0, len(keys))
+
+	for k, v := range keys {
+		params = append(params, slog.Any(string(k), v))
+	}
+
+	return params
+}

--- a/logger/newlogger/adapter/slog/helper.go
+++ b/logger/newlogger/adapter/slog/helper.go
@@ -5,8 +5,8 @@ import (
 	"log/slog"
 )
 
-func logParamsToSlogParams(keys map[loggerparam.ExtraKey]interface{}) []any {
-	params := make([]any, 0, len(keys))
+func logParamsToSlogParams(keys map[loggerparam.ExtraKey]interface{}) []slog.Attr {
+	params := make([]slog.Attr, 0, len(keys))
 
 	for k, v := range keys {
 		params = append(params, slog.Any(string(k), v))

--- a/logger/newlogger/adapter/slog/slog.go
+++ b/logger/newlogger/adapter/slog/slog.go
@@ -39,6 +39,7 @@ type Config struct {
 func NewSlog(cfg Config) *Slog {
 	logger := &Slog{config: cfg}
 	logger.Init()
+
 	return logger
 }
 
@@ -67,9 +68,7 @@ func (s *Slog) Init() {
 	})
 }
 
-func (s *Slog) Debug(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
-	extra map[loggerparam.ExtraKey]interface{}) {
-
+func (s *Slog) Debug(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{}) {
 	params := prepareLogInfo(cat, sub, extra)
 	s.logger.Debug(msg, params...)
 }
@@ -78,8 +77,7 @@ func (s *Slog) Debugf(template string, args ...interface{}) {
 	s.logger.Debug(fmt.Sprintf(template, args...))
 }
 
-func (s *Slog) Info(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
-	extra map[loggerparam.ExtraKey]interface{}) {
+func (s *Slog) Info(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{}) {
 	params := prepareLogInfo(cat, sub, extra)
 	s.logger.Info(msg, params...)
 }
@@ -88,9 +86,7 @@ func (s *Slog) Infof(template string, args ...interface{}) {
 	s.logger.Info(fmt.Sprintf(template, args...))
 }
 
-func (s *Slog) Warn(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
-	extra map[loggerparam.ExtraKey]interface{}) {
-
+func (s *Slog) Warn(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{}) {
 	params := prepareLogInfo(cat, sub, extra)
 	s.logger.Warn(msg, params...)
 }
@@ -99,9 +95,7 @@ func (s *Slog) Warnf(template string, args ...interface{}) {
 	s.logger.Warn(fmt.Sprintf(template, args...))
 }
 
-func (s *Slog) Error(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
-	extra map[loggerparam.ExtraKey]interface{}) {
-
+func (s *Slog) Error(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{}) {
 	params := prepareLogInfo(cat, sub, extra)
 	s.logger.Error(msg, params...)
 }
@@ -110,18 +104,15 @@ func (s *Slog) Errorf(template string, args ...interface{}) {
 	s.logger.Error(fmt.Sprintf(template, args...))
 }
 
-func (s *Slog) Fatal(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
-	extra map[loggerparam.ExtraKey]interface{}) {
+func (s *Slog) Fatal(_ loggerparam.Category, _ loggerparam.SubCategory, _ string, _ map[loggerparam.ExtraKey]interface{}) {
 	s.logger.Error("Fatal not supported")
 }
 
-func (s *Slog) Fatalf(template string, args ...interface{}) {
+func (s *Slog) Fatalf(_ string, _ ...interface{}) {
 	s.logger.Error("Fatal not supported")
 }
 
-func prepareLogInfo(cat loggerparam.Category, sub loggerparam.SubCategory,
-	extra map[loggerparam.ExtraKey]interface{}) []any {
-
+func prepareLogInfo(cat loggerparam.Category, sub loggerparam.SubCategory, extra map[loggerparam.ExtraKey]interface{}) []any {
 	if extra == nil {
 		extra = make(map[loggerparam.ExtraKey]interface{})
 	}

--- a/logger/newlogger/adapter/slog/slog.go
+++ b/logger/newlogger/adapter/slog/slog.go
@@ -1,0 +1,132 @@
+package slog
+
+import (
+	"fmt"
+	"github.com/ormushq/ormus/logger/newlogger/loggerparam"
+	"gopkg.in/natefinch/lumberjack.v2"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+type Slog struct {
+	config Config
+	logger *slog.Logger
+}
+
+var (
+	DriverName       = "slog"
+	once             = sync.Once{}
+	slogLevelMapping = map[string]slog.Level{
+		"debug": slog.LevelDebug,
+		"info":  slog.LevelInfo,
+		"warn":  slog.LevelWarn,
+		"error": slog.LevelError,
+	}
+)
+
+type Config struct {
+	Level      string
+	Filename   string
+	Filepath   string
+	LocalTime  bool
+	MaxBackups int
+	MaxSize    int
+	MaxAge     int
+}
+
+func NewSlog(cfg Config) *Slog {
+	logger := &Slog{config: cfg}
+	logger.Init()
+	return logger
+}
+
+func (s *Slog) getLogLevel() slog.Level {
+	level, exists := slogLevelMapping[s.config.Level]
+	if !exists {
+		level = slog.LevelDebug
+	}
+
+	return level
+}
+
+func (s *Slog) Init() {
+	once.Do(func() {
+		fileWriter := &lumberjack.Logger{
+			Filename:   s.config.Filename,
+			LocalTime:  s.config.LocalTime,
+			MaxSize:    s.config.MaxSize,
+			MaxBackups: s.config.MaxBackups,
+			MaxAge:     s.config.MaxAge,
+		}
+		logger := slog.New(
+			slog.NewJSONHandler(io.MultiWriter(fileWriter, os.Stdout), &slog.HandlerOptions{Level: s.getLogLevel()}),
+		)
+		s.logger = logger
+	})
+}
+
+func (s *Slog) Debug(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
+	extra map[loggerparam.ExtraKey]interface{}) {
+
+	params := prepareLogInfo(cat, sub, extra)
+	s.logger.Debug(msg, params...)
+}
+
+func (s *Slog) Debugf(template string, args ...interface{}) {
+	s.logger.Debug(fmt.Sprintf(template, args...))
+}
+
+func (s *Slog) Info(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
+	extra map[loggerparam.ExtraKey]interface{}) {
+	params := prepareLogInfo(cat, sub, extra)
+	s.logger.Info(msg, params...)
+}
+
+func (s *Slog) Infof(template string, args ...interface{}) {
+	s.logger.Info(fmt.Sprintf(template, args...))
+}
+
+func (s *Slog) Warn(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
+	extra map[loggerparam.ExtraKey]interface{}) {
+
+	params := prepareLogInfo(cat, sub, extra)
+	s.logger.Warn(msg, params...)
+}
+
+func (s *Slog) Warnf(template string, args ...interface{}) {
+	s.logger.Warn(fmt.Sprintf(template, args...))
+}
+
+func (s *Slog) Error(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
+	extra map[loggerparam.ExtraKey]interface{}) {
+
+	params := prepareLogInfo(cat, sub, extra)
+	s.logger.Error(msg, params...)
+}
+
+func (s *Slog) Errorf(template string, args ...interface{}) {
+	s.logger.Error(fmt.Sprintf(template, args...))
+}
+
+func (s *Slog) Fatal(cat loggerparam.Category, sub loggerparam.SubCategory, msg string,
+	extra map[loggerparam.ExtraKey]interface{}) {
+	s.logger.Error("Fatal not supported")
+}
+
+func (s *Slog) Fatalf(template string, args ...interface{}) {
+	s.logger.Error("Fatal not supported")
+}
+
+func prepareLogInfo(cat loggerparam.Category, sub loggerparam.SubCategory,
+	extra map[loggerparam.ExtraKey]interface{}) []any {
+
+	if extra == nil {
+		extra = make(map[loggerparam.ExtraKey]interface{})
+	}
+	extra["Category"] = cat
+	extra["SubCategory"] = sub
+
+	return logParamsToSlogParams(extra)
+}

--- a/logger/newlogger/log.go
+++ b/logger/newlogger/log.go
@@ -12,6 +12,8 @@ type Log struct {
 	extra map[loggerparam.ExtraKey]interface{}
 }
 
+const runtimeCallerSkip = 3
+
 func NewLog(msg string) *Log {
 	return &Log{
 		cat:   loggerparam.CategoryNotDefined,
@@ -22,7 +24,7 @@ func NewLog(msg string) *Log {
 }
 
 func (l *Log) WithTrace() *Log {
-	return l.With(loggerparam.ExtraKeyTrace, newtrace.Parse(0))
+	return l.With(loggerparam.ExtraKeyTrace, newtrace.Parse(runtimeCallerSkip))
 }
 
 func (l *Log) WithCategory(cat loggerparam.Category) *Log {

--- a/logger/newlogger/log.go
+++ b/logger/newlogger/log.go
@@ -1,0 +1,59 @@
+package newlogger
+
+import (
+	"github.com/ormushq/ormus/logger/newlogger/loggerparam"
+	"github.com/ormushq/ormus/pkg/trace/newtrace"
+)
+
+type Log struct {
+	cat   loggerparam.Category
+	sub   loggerparam.SubCategory
+	msg   string
+	extra map[loggerparam.ExtraKey]interface{}
+}
+
+func NewLog(msg string) *Log {
+	return &Log{
+		cat:   loggerparam.CategoryNotDefined,
+		sub:   loggerparam.SubCategoryNotDefined,
+		msg:   msg,
+		extra: map[loggerparam.ExtraKey]interface{}{},
+	}
+}
+
+func (l *Log) WithTrace() *Log {
+	return l.With(loggerparam.ExtraKeyTrace, newtrace.Parse(0))
+}
+func (l *Log) WithCategory(cat loggerparam.Category) *Log {
+	l.cat = cat
+	return l
+}
+
+func (l *Log) WithSubCategory(sub loggerparam.SubCategory) *Log {
+	l.sub = sub
+	return l
+}
+func (l *Log) With(key loggerparam.ExtraKey, value interface{}) *Log {
+	l.extra[key] = value
+	return l
+}
+
+func (l *Log) Debug() {
+	L().Debug(l.cat, l.sub, l.msg, l.extra)
+}
+
+func (l *Log) Info() {
+	L().Info(l.cat, l.sub, l.msg, l.extra)
+}
+
+func (l *Log) Warn() {
+	L().Warn(l.cat, l.sub, l.msg, l.extra)
+}
+
+func (l *Log) Error() {
+	L().Error(l.cat, l.sub, l.msg, l.extra)
+}
+
+func (l *Log) Fatal() {
+	L().Fatal(l.cat, l.sub, l.msg, l.extra)
+}

--- a/logger/newlogger/log.go
+++ b/logger/newlogger/log.go
@@ -24,17 +24,22 @@ func NewLog(msg string) *Log {
 func (l *Log) WithTrace() *Log {
 	return l.With(loggerparam.ExtraKeyTrace, newtrace.Parse(0))
 }
+
 func (l *Log) WithCategory(cat loggerparam.Category) *Log {
 	l.cat = cat
+
 	return l
 }
 
 func (l *Log) WithSubCategory(sub loggerparam.SubCategory) *Log {
 	l.sub = sub
+
 	return l
 }
+
 func (l *Log) With(key loggerparam.ExtraKey, value interface{}) *Log {
 	l.extra[key] = value
+
 	return l
 }
 

--- a/logger/newlogger/logger.go
+++ b/logger/newlogger/logger.go
@@ -52,6 +52,7 @@ func NewLogger(cfg Config) Logger {
 				MaxSize:    cfg.MaxSize,
 				MaxAge:     cfg.MaxAge,
 			})
+
 			return
 		}
 		panic("logger not supported")
@@ -64,5 +65,6 @@ func L() Logger {
 	if logger == nil {
 		panic("you need to init logger first")
 	}
+
 	return logger
 }

--- a/logger/newlogger/logger.go
+++ b/logger/newlogger/logger.go
@@ -1,0 +1,68 @@
+package newlogger
+
+import (
+	"github.com/ormushq/ormus/logger/newlogger/adapter/slog"
+	"github.com/ormushq/ormus/logger/newlogger/loggerparam"
+	"sync"
+)
+
+type Config struct {
+	Driver     string `koanf:"driver"`
+	Level      string `koanf:"level"`
+	Filepath   string `koanf:"filepath"`
+	LocalTime  bool   `koanf:"local_time"`
+	MaxBackups int    `koanf:"max_backups"`
+	MaxSize    int    `koanf:"max_size"`
+	MaxAge     int    `koanf:"max_ager"`
+}
+
+type Logger interface {
+	Init()
+
+	Debug(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{})
+	Debugf(template string, args ...interface{})
+
+	Info(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{})
+	Infof(template string, args ...interface{})
+
+	Warn(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{})
+	Warnf(template string, args ...interface{})
+
+	Error(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{})
+	Errorf(template string, args ...interface{})
+
+	Fatal(cat loggerparam.Category, sub loggerparam.SubCategory, msg string, extra map[loggerparam.ExtraKey]interface{})
+	Fatalf(template string, args ...interface{})
+}
+
+var (
+	once   = sync.Once{}
+	logger Logger
+)
+
+func NewLogger(cfg Config) Logger {
+	once.Do(func() {
+		if cfg.Driver == slog.DriverName {
+			logger = slog.NewSlog(slog.Config{
+				Level:      cfg.Level,
+				Filename:   cfg.Filepath,
+				Filepath:   cfg.Filepath,
+				LocalTime:  cfg.LocalTime,
+				MaxBackups: cfg.MaxBackups,
+				MaxSize:    cfg.MaxSize,
+				MaxAge:     cfg.MaxAge,
+			})
+			return
+		}
+		panic("logger not supported")
+	})
+
+	return logger
+}
+
+func L() Logger {
+	if logger == nil {
+		panic("you need to init logger first")
+	}
+	return logger
+}

--- a/logger/newlogger/loggerparam/category.go
+++ b/logger/newlogger/loggerparam/category.go
@@ -1,0 +1,7 @@
+package loggerparam
+
+type Category string
+
+const (
+	CategoryNotDefined Category = "NotDefined"
+)

--- a/logger/newlogger/loggerparam/extrakey.go
+++ b/logger/newlogger/loggerparam/extrakey.go
@@ -1,0 +1,8 @@
+package loggerparam
+
+type ExtraKey string
+
+const (
+	ExtraKeyNotDefined ExtraKey = "NotDefined"
+	ExtraKeyTrace      ExtraKey = "Trace"
+)

--- a/logger/newlogger/loggerparam/subcategory.go
+++ b/logger/newlogger/loggerparam/subcategory.go
@@ -1,0 +1,7 @@
+package loggerparam
+
+type SubCategory string
+
+const (
+	SubCategoryNotDefined SubCategory = "Not defined"
+)

--- a/pkg/trace/newtrace/trace.go
+++ b/pkg/trace/newtrace/trace.go
@@ -1,0 +1,28 @@
+package newtrace
+
+import (
+	"runtime"
+)
+
+type Trace struct {
+	File     string
+	Line     int
+	Function string
+}
+
+func Parse(runtimeCallerSkip int) Trace {
+	pcSize := 10
+	if runtimeCallerSkip == 0 {
+		runtimeCallerSkip = 5
+	}
+	pc := make([]uintptr, pcSize)
+	runtime.Callers(runtimeCallerSkip, pc)
+	f := runtime.FuncForPC(pc[0])
+	file, line := f.FileLine(pc[0])
+
+	return Trace{
+		File:     file,
+		Line:     line,
+		Function: f.Name(),
+	}
+}

--- a/pkg/trace/newtrace/trace.go
+++ b/pkg/trace/newtrace/trace.go
@@ -17,6 +17,7 @@ func Parse(runtimeCallerSkip int) Trace {
 	pc = pc[:n]
 	frames := runtime.CallersFrames(pc)
 	frame, _ := frames.Next()
+
 	return Trace{
 		File:     frame.File,
 		Line:     frame.Line,

--- a/pkg/trace/newtrace/trace.go
+++ b/pkg/trace/newtrace/trace.go
@@ -12,17 +12,14 @@ type Trace struct {
 
 func Parse(runtimeCallerSkip int) Trace {
 	pcSize := 10
-	if runtimeCallerSkip == 0 {
-		runtimeCallerSkip = 5
-	}
 	pc := make([]uintptr, pcSize)
-	runtime.Callers(runtimeCallerSkip, pc)
-	f := runtime.FuncForPC(pc[0])
-	file, line := f.FileLine(pc[0])
-
+	n := runtime.Callers(runtimeCallerSkip, pc)
+	pc = pc[:n]
+	frames := runtime.CallersFrames(pc)
+	frame, _ := frames.Next()
 	return Trace{
-		File:     file,
-		Line:     line,
-		Function: f.Name(),
+		File:     frame.File,
+		Line:     frame.Line,
+		Function: frame.Function,
 	}
 }


### PR DESCRIPTION
To avoid making the project dependent on a specific logger, I created an abstract logging interface and implemented the slog as an adapter.