### PR TITLE
fix(ormus): Update make file and ci github flow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
         run: sudo docker-compose down
 
       - name: Format
-        run: make format
+        run: make format-check
 
       - name: Lint
         run: make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,5 @@ jobs:
       - name: dockerDown
         run: sudo docker-compose down
 
-      - name: Format
-        run: make format-check
-
       - name: Lint
         run: make lint

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,16 @@ down:
 logs:
 	docker-compose logs
 
-format:
+format-fix:
 	@which gofumpt || (go install mvdan.cc/gofumpt@latest)
 	@gofumpt -l -w $(ROOT)
 	@which gci || (go install github.com/daixiang0/gci@latest)
 	@gci write $(ROOT)
 	@which golangci-lint || (go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0)
 	@golangci-lint run --fix
+
+format-check:
+	@which gofumpt || (go install mvdan.cc/gofumpt@latest)
+	@gofumpt -l $(ROOT)
+	@which gci || (go install github.com/daixiang0/gci@latest)
+	@gci list $(ROOT)

--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,10 @@ down:
 logs:
 	docker-compose logs
 
-format-fix:
+format:
 	@which gofumpt || (go install mvdan.cc/gofumpt@latest)
 	@gofumpt -l -w $(ROOT)
 	@which gci || (go install github.com/daixiang0/gci@latest)
 	@gci write $(ROOT)
 	@which golangci-lint || (go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0)
 	@golangci-lint run --fix
-
-format-check:
-	@which gofumpt || (go install mvdan.cc/gofumpt@latest)
-	@gofumpt -l $(ROOT)
-	@which gci || (go install github.com/daixiang0/gci@latest)
-	@gci list $(ROOT)


### PR DESCRIPTION
I removed the format step from the GitHub flow because it was altering the code format. Please run `make format` before pushing your changes. If you don't run `make format`, the lint step in the CI will produce errors.