### PR TITLE
fix(manager): change simple channel type to channel adapter interface

### DIFF
--- a/manager/service/projectservice/service.go
+++ b/manager/service/projectservice/service.go
@@ -2,7 +2,7 @@ package projectservice
 
 import (
 	"github.com/ormushq/ormus/manager/entity"
-	"github.com/ormushq/ormus/pkg/channel/adapter/simple"
+	"github.com/ormushq/ormus/pkg/channel"
 )
 
 type Repository interface {
@@ -11,10 +11,10 @@ type Repository interface {
 
 type Service struct {
 	repo           Repository
-	internalBroker *simple.ChannelAdapter
+	internalBroker channel.Adapter
 }
 
-func New(repository Repository, internalBroker *simple.ChannelAdapter) *Service {
+func New(repository Repository, internalBroker channel.Adapter) *Service {
 	return &Service{
 		repo:           repository,
 		internalBroker: internalBroker,

--- a/manager/service/userservice/service.go
+++ b/manager/service/userservice/service.go
@@ -3,7 +3,7 @@ package userservice
 import (
 	"github.com/ormushq/ormus/manager/entity"
 	"github.com/ormushq/ormus/manager/validator/uservalidator"
-	"github.com/ormushq/ormus/pkg/channel/adapter/simple"
+	"github.com/ormushq/ormus/pkg/channel"
 )
 
 type Repository interface {
@@ -21,7 +21,7 @@ type Service struct {
 	repo           Repository
 	jwt            JWTEngine
 	userValidator  uservalidator.Validator
-	internalBroker *simple.ChannelAdapter
+	internalBroker channel.Adapter
 }
 
 // This benchmark is the result of using a pointer, or a struct in return of New() function of this package
@@ -34,7 +34,7 @@ type Service struct {
 // PASS
 // ok      github.com/ormushq/ormus/manager/service        2.590s
 
-func New(authGenerator JWTEngine, repository Repository, internalBroker *simple.ChannelAdapter, userValidator uservalidator.Validator) *Service {
+func New(authGenerator JWTEngine, repository Repository, internalBroker channel.Adapter, userValidator uservalidator.Validator) *Service {
 	return &Service{
 		jwt:            authGenerator,
 		repo:           repository,


### PR DESCRIPTION
Change internal broker type to channel interface in future maybe we change it to RabbitMQ then we just pass RabbitMQ adapter to this service and no more changes are required.