### PR TITLE
fix(ormus): add new helper to otela package.

### DIFF
--- a/adapter/otela/config.go
+++ b/adapter/otela/config.go
@@ -1,0 +1,9 @@
+package otela
+
+type Otel struct {
+	Endpoint           string `koanf:"endpoint"`
+	ServiceName        string `koanf:"service_name"`
+	EnableMetricExpose bool   `koanf:"enable_metric_expose"`
+	MetricExposePort   int    `koanf:"metric_expose_port"`
+	MetricExposePath   string `koanf:"metric_expose_path"`
+}

--- a/adapter/otela/echorequestloggerlogvaluesfunc.go
+++ b/adapter/otela/echorequestloggerlogvaluesfunc.go
@@ -1,0 +1,111 @@
+package otela
+
+import (
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func EchoRequestLoggerLogValuesFunc(packageName, functionName string) func(c echo.Context, v middleware.RequestLoggerValues) error {
+	return func(c echo.Context, v middleware.RequestLoggerValues) error {
+		errMsg := ""
+		if v.Error != nil {
+			errMsg = v.Error.Error()
+		}
+
+		attributes := make([]attribute.KeyValue, 0)
+
+		t := time.Time{}
+		if v.StartTime != t {
+			attributes = append(attributes, attribute.String("StartTime", v.StartTime.String()))
+		}
+		if v.Latency != 0 {
+			attributes = append(attributes, attribute.Float64("Latency", v.Latency.Seconds()))
+		}
+
+		if v.Protocol != "" {
+			attributes = append(attributes, attribute.String("Protocol", v.Protocol))
+		}
+
+		if v.RemoteIP != "" {
+			attributes = append(attributes, attribute.String("RemoteIP", v.RemoteIP))
+		}
+
+		if v.Host != "" {
+			attributes = append(attributes, attribute.String("Host", v.Host))
+		}
+
+		if v.Method != "" {
+			attributes = append(attributes, attribute.String("Method", v.Method))
+		}
+
+		if v.URI != "" {
+			attributes = append(attributes, attribute.String("URI", v.URI))
+		}
+
+		if v.URIPath != "" {
+			attributes = append(attributes, attribute.String("URIPath", v.URIPath))
+		}
+
+		if v.RoutePath != "" {
+			attributes = append(attributes, attribute.String("RoutePath", v.RoutePath))
+		}
+
+		if v.RequestID != "" {
+			attributes = append(attributes, attribute.String("RequestID", v.RequestID))
+		}
+
+		if v.Referer != "" {
+			attributes = append(attributes, attribute.String("Referer", v.Referer))
+		}
+
+		if v.UserAgent != "" {
+			attributes = append(attributes, attribute.String("UserAgent", v.UserAgent))
+		}
+
+		if v.Status != 0 {
+			attributes = append(attributes, attribute.Int("Status", v.Status))
+		}
+
+		if errMsg != "" {
+			attributes = append(attributes, attribute.String("ErrMsg", errMsg))
+		}
+
+		if v.ContentLength != "" {
+			attributes = append(attributes, attribute.String("ContentLength", v.ContentLength))
+		}
+
+		if v.ResponseSize != 0 {
+			attributes = append(attributes, attribute.Int64("ResponseSize", v.ResponseSize))
+		}
+
+		if v.Headers != nil {
+			for key, value := range v.Headers {
+				attributes = append(attributes, attribute.String("Headers."+key, strings.Join(value, ",")))
+			}
+		}
+
+		if v.QueryParams != nil {
+			for key, value := range v.QueryParams {
+				attributes = append(attributes, attribute.String("QueryParams."+key, strings.Join(value, ",")))
+			}
+		}
+
+		if v.FormValues != nil {
+			for key, value := range v.FormValues {
+				attributes = append(attributes, attribute.String("QueryParams."+key, strings.Join(value, ",")))
+			}
+		}
+
+		ctx, _ := TraceBuilder(packageName, functionName,
+			WithContext(c.Request().Context()),
+			WithSpanOptionAttributes(attributes...),
+		)
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		return nil
+	}
+}

--- a/adapter/otela/tracebuilder.go
+++ b/adapter/otela/tracebuilder.go
@@ -26,6 +26,9 @@ func TraceBuilder(packageName, functionName string, options ...TracerOptions) (c
 			traceOpt.tracerOptions = option.tracerOptions
 		}
 	}
+	if traceOpt.ctx == nil {
+		traceOpt.ctx = context.Background()
+	}
 	tracer := NewTracer(packageName, traceOpt.tracerOptions...)
 
 	return tracer.Start(traceOpt.ctx, packageName+"@"+functionName, traceOpt.spanOptions...)

--- a/adapter/otela/tracebuilder.go
+++ b/adapter/otela/tracebuilder.go
@@ -27,6 +27,7 @@ func TraceBuilder(packageName, functionName string, options ...TracerOptions) (c
 		}
 	}
 	tracer := NewTracer(packageName, traceOpt.tracerOptions...)
+
 	return tracer.Start(traceOpt.ctx, packageName+"@"+functionName, traceOpt.spanOptions...)
 }
 

--- a/adapter/otela/tracebuilder.go
+++ b/adapter/otela/tracebuilder.go
@@ -1,0 +1,63 @@
+package otela
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type TracerOptions struct {
+	ctx           context.Context
+	tracerOptions []trace.TracerOption
+	spanOptions   []trace.SpanStartOption
+}
+
+func TraceBuilder(packageName, functionName string, options ...TracerOptions) (context.Context, trace.Span) {
+	traceOpt := TracerOptions{}
+	for _, option := range options {
+		if option.ctx != nil {
+			traceOpt.ctx = option.ctx
+		}
+		if option.spanOptions != nil {
+			traceOpt.spanOptions = option.spanOptions
+		}
+		if option.tracerOptions != nil {
+			traceOpt.tracerOptions = option.tracerOptions
+		}
+	}
+	tracer := NewTracer(packageName, traceOpt.tracerOptions...)
+	return tracer.Start(traceOpt.ctx, packageName+"@"+functionName, traceOpt.spanOptions...)
+}
+
+func WithCarrier(carrier map[string]string) TracerOptions {
+	return TracerOptions{
+		ctx: GetContextFromCarrier(carrier),
+	}
+}
+
+func WithContext(ctx context.Context) TracerOptions {
+	return TracerOptions{
+		ctx: ctx,
+	}
+}
+
+func WithTracerOptions(options ...trace.TracerOption) TracerOptions {
+	return TracerOptions{
+		tracerOptions: options,
+	}
+}
+
+func WithSpanOptions(options ...trace.SpanStartOption) TracerOptions {
+	return TracerOptions{
+		spanOptions: options,
+	}
+}
+
+func WithSpanOptionAttributes(attributes ...attribute.KeyValue) TracerOptions {
+	return TracerOptions{
+		spanOptions: []trace.SpanStartOption{
+			trace.WithAttributes(attributes...),
+		},
+	}
+}

--- a/cmd/source/main.go
+++ b/cmd/source/main.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/ormushq/ormus/adapter/otela"
 	"github.com/ormushq/ormus/config"
+	"github.com/ormushq/ormus/logger"
 	"github.com/ormushq/ormus/source/delivery/httpserver"
 	"github.com/ormushq/ormus/source/delivery/httpserver/statushandler"
 )
@@ -20,11 +27,62 @@ import (
 //	@name						Authorization
 
 func main() {
+	done := make(chan bool)
+	wg := &sync.WaitGroup{}
+
+	//----------------- Setup Logger -----------------//
+	fileMaxSizeInMB := 10
+	fileMaxAgeInDays := 30
+
+	loggercfg := logger.Config{
+		FilePath:         "./destination/logs.json",
+		UseLocalTime:     false,
+		FileMaxSizeInMB:  fileMaxSizeInMB,
+		FileMaxAgeInDays: fileMaxAgeInDays,
+	}
+
+	logLevel := slog.LevelInfo
+	if config.C().Destination.DebugMode {
+		logLevel = slog.LevelDebug
+	}
+
+	opt := slog.HandlerOptions{
+		// todo should level debug be read from config?
+		Level: logLevel,
+	}
+	l := logger.New(loggercfg, &opt)
+
+	// use slog as default logger.
+	slog.SetDefault(l)
+
 	handlers := []httpserver.Handler{
 		statushandler.New(),
+	}
+
+	//----------------- Setup Tracer -----------------//
+	otelcfg := otela.Config{
+		Endpoint:           config.C().Source.Otel.Endpoint,
+		ServiceName:        config.C().Source.Otel.ServiceName,
+		EnableMetricExpose: config.C().Source.Otel.EnableMetricExpose,
+		MetricExposePath:   config.C().Source.Otel.MetricExposePath,
+		MetricExposePort:   config.C().Source.Otel.MetricExposePort,
+		Exporter:           otela.ExporterGrpc,
+	}
+	err := otela.Configure(wg, done, otelcfg)
+	if err != nil {
+		l.Error(err.Error())
 	}
 
 	httpServer := httpserver.New(config.C().Source, handlers)
 
 	httpServer.Serve()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt)
+	<-quit
+	slog.Info("Received interrupt signal, shutting down gracefully...")
+	done <- true
+
+	close(done)
+	wg.Wait()
 }

--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,12 @@ source:
   http_server:
     port: 8080
     network: "tcp"
+  otel:
+    endpoint: "otel_collector:4317"
+    service_name: "source"
+    enable_metric_expose: true
+    metric_expose_port: 8081
+    metric_expose_path: "metrics"
 scylladb:
   hosts:
     - 127.0.0.1:9042

--- a/doc/otel_usage.md
+++ b/doc/otel_usage.md
@@ -89,28 +89,28 @@ counter.Add(context.Background(), 1)
 
 There is two helper method: `otela.AddFloat64Counter` and `otela.IncrementFloat64Counter` 
 
+
 ## Trace helper
 
 ### `GetCarrierFromContext(ctx context.Context) map[string]string`
-For extract carrier from context use this method. 
-This method is useful when you want pass tracer id between services that in separate binaries and they use eventing or messaging design pattern.
-You can simply in client service set tracerId with this value and pass it to host and with below function generate context with this value and use it in host service.
+To extract the carrier from the context, use this method. It's particularly useful when passing a tracer ID between services running in separate binaries, especially in event-driven or messaging-based design patterns. On the client service, you can easily set the tracer ID with this value, pass it to the host, and then use the following function to generate a context with the tracer ID for use in the host service.
 
 ### `GetContextFromCarrier(carrier map[string]string) context.Context`
-As mention in top you can use this method to convert tracer id to context.
+As mentioned above, you can use this method to convert the tracer ID into a context.
+
 
 ## Trace builder
 
 ``go
 TraceBuilder(packageName, functionName string, options ...TracerOptions) (context.Context, trace.Span)
 ``
-Use this method for easy use of OTEL collector. just like this:
+You can use this method for easy integration with the Otel collector, like this:
 ```go
 ctx, span := otela.TraceBuilder("package name", "Function name",
     TracerOptions...),
 )
 ```
-There is some helper function for generate TraceOption like :
+Here is a helper function for generating `TraceOption`, such as:
 - `WithCarrier(carrier map[string]string) TracerOptions`
 - `WithContext(ctx context.Context) TracerOptions`
 - `WithTracerOptions(options ...trace.TracerOption) TracerOptions`
@@ -118,10 +118,9 @@ There is some helper function for generate TraceOption like :
 - `WithSpanOptionAttributes(attributes ...attribute.KeyValue) TracerOptions`
 
 
-
 ## Log echo requests
 
-In delivery layer you can register the otela log as below:
+In the delivery layer, you can register the Otel log as shown below:
 
 ```go
     s.Router.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
@@ -139,7 +138,7 @@ In delivery layer you can register the otela log as below:
 		LogValuesFunc:    otela.EchoRequestLoggerLogValuesFunc("httpserver", "Serve"),
 	}))
 ```
-Then it start span on request and inject trace id to the context, you can continue to append spans to the tracer like below:
+It then starts the tracer on the request and injects the trace ID into the context. You can continue to append spans to the tracer as shown below:
 
 ```go
 package statushandler

--- a/source/config.go
+++ b/source/config.go
@@ -1,5 +1,7 @@
 package source
 
+import "github.com/ormushq/ormus/adapter/otela"
+
 // HTTPServer is the main object for http configurations.
 type HTTPServer struct {
 	Port    int    `koanf:"port"`
@@ -10,4 +12,5 @@ type HTTPServer struct {
 type Config struct {
 	HTTPServer HTTPServer `koanf:"http_server"`
 	// TODO - add source, auth and etc configurations
+	Otel otela.Otel `koanf:"otel"`
 }

--- a/source/delivery/httpserver/server.go
+++ b/source/delivery/httpserver/server.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/ormushq/ormus/adapter/otela"
 	"github.com/ormushq/ormus/source"
 )
 
@@ -35,6 +37,20 @@ func (s Server) Serve() {
 	for _, h := range s.handlers {
 		h.SetRoutes(s.Router)
 	}
+	s.Router.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogURI:           true,
+		LogStatus:        true,
+		LogHost:          true,
+		LogRemoteIP:      true,
+		LogRequestID:     true,
+		LogMethod:        true,
+		LogContentLength: true,
+		LogResponseSize:  true,
+		LogLatency:       true,
+		LogError:         true,
+		LogProtocol:      true,
+		LogValuesFunc:    otela.EchoRequestLoggerLogValuesFunc("httpserver-source", "Serve"),
+	}))
 
 	port := fmt.Sprintf(":%d", s.config.HTTPServer.Port)
 	s.Router.Logger.Fatal(s.Router.Start(port))

--- a/source/delivery/httpserver/statushandler/status.go
+++ b/source/delivery/httpserver/statushandler/status.go
@@ -4,10 +4,21 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/ormushq/ormus/adapter/otela"
 	"github.com/ormushq/ormus/source/params"
 )
 
 func (h Handler) status(ctx echo.Context) error {
+	// You can pass newCtx to service for set this span as parent of spans that start in services
+	_, span := otela.TraceBuilder("statushandler", "status",
+		otela.WithContext(ctx.Request().Context()),
+	)
+	defer span.End()
+
+	span.AddEvent("Starting status handler")
+	// Do something
+	span.AddEvent("Ending status handler")
+
 	return ctx.JSON(http.StatusOK, params.StatusResponse{
 		Message: "System is functioning correctly.",
 	})


### PR DESCRIPTION
I added two helper functions to the Otela package and implemented Otela in the source project. The trace helpers were already included; I've just added documentation on how to use them here. The documentation is included in `docs/otel_usage.md`.


## Trace helper

### `GetCarrierFromContext(ctx context.Context) map[string]string`
To extract the carrier from the context, use this method. It's particularly useful when passing a tracer ID between services running in separate binaries, especially in event-driven or messaging-based design patterns. On the client service, you can easily set the tracer ID with this value, pass it to the host, and then use the following function to generate a context with the tracer ID for use in the host service.

### `GetContextFromCarrier(carrier map[string]string) context.Context`
As mentioned above, you can use this method to convert the tracer ID into a context.


## Trace builder

``go
TraceBuilder(packageName, functionName string, options ...TracerOptions) (context.Context, trace.Span)
``
You can use this method for easy integration with the Otel collector, like this:
```go
ctx, span := otela.TraceBuilder("package name", "Function name",
    TracerOptions...),
)
```
Here is a helper function for generating `TraceOption`, such as:
- `WithCarrier(carrier map[string]string) TracerOptions`
- `WithContext(ctx context.Context) TracerOptions`
- `WithTracerOptions(options ...trace.TracerOption) TracerOptions`
- `WithSpanOptions(options ...trace.SpanStartOption) TracerOptions`
- `WithSpanOptionAttributes(attributes ...attribute.KeyValue) TracerOptions`


## Log echo requests

In the delivery layer, you can register the Otel log as shown below:

```go
    s.Router.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
		LogURI:           true,
		LogStatus:        true,
		LogHost:          true,
		LogRemoteIP:      true,
		LogRequestID:     true,
		LogMethod:        true,
		LogContentLength: true,
		LogResponseSize:  true,
		LogLatency:       true,
		LogError:         true,
		LogProtocol:      true,
		LogValuesFunc:    otela.EchoRequestLoggerLogValuesFunc("httpserver", "Serve"),
	}))
```
It then starts the tracer on the request and injects the trace ID into the context. You can continue to append spans to the tracer as shown below:

```go
package statushandler

import (
	"github.com/ormushq/ormus/adapter/otela"
	"github.com/labstack/echo/v4"
)


    func (h Handler) healthCheck(c echo.Context) error {

        // You can pass newCtx to service for set this span as parent of spans that start in services 
        newCtx, span := otela.TraceBuilder("statushandler", "status",
        otela.WithContext(ctx.Request().Context()),
        )
        defer span.End()
        
        span.AddEvent("Starting status handler")
        // Do something
        span.AddEvent("Ending status handler")
		
        ...
    }
        
```